### PR TITLE
adapt to z80pack changes, fix CPU_M1 not cleared in memwrt()/memrdr()

### DIFF
--- a/srcsim/CMakeLists.txt
+++ b/srcsim/CMakeLists.txt
@@ -49,7 +49,6 @@ add_executable(${PROJECT_NAME}
 	${Z80PACK}/z80core/simdis.c
 	${Z80PACK}/z80core/simglb.c
 	${Z80PACK}/z80core/simice.c
-	${Z80PACK}/z80core/simutil.c
 	${Z80PACK}/z80core/simz80-cb.c
 	${Z80PACK}/z80core/simz80-dd.c
 	${Z80PACK}/z80core/simz80-ddcb.c

--- a/srcsim/simcfg.c
+++ b/srcsim/simcfg.c
@@ -33,7 +33,6 @@
 #include "simdefs.h"
 #include "simglb.h"
 #include "simcore.h"
-#include "simutil.h"
 #include "simport.h"
 #include "simio.h"
 #include "simcfg.h"

--- a/srcsim/simmem.h
+++ b/srcsim/simmem.h
@@ -35,7 +35,7 @@ extern void init_memory(void), reset_memory(void);
 static inline void memwrt(WORD addr, BYTE data)
 {
 #ifdef BUS_8080
-	cpu_bus &= ~(CPU_WO | CPU_MEMR);
+	cpu_bus &= ~(CPU_WO | CPU_M1 | CPU_MEMR);
 #endif
 
 #ifdef SIMPLEPANEL
@@ -61,6 +61,7 @@ static inline BYTE memrdr(WORD addr)
 		data = bnk1[addr];
 
 #ifdef BUS_8080
+	cpu_bus &= ~CPU_M1;
 	cpu_bus |= CPU_WO | CPU_MEMR;
 #endif
 


### PR DESCRIPTION
CPU_M1 is cleared by the wait_step() function defined and used by z80pack simulators with FRONTPANEL, but not here with SIMPLEPANEL.