### PR TITLE
don't use the hardware divider emulation on RP2350 & check if the DS3231 is really there

### DIFF
--- a/srcsim/lcd.c
+++ b/srcsim/lcd.c
@@ -10,7 +10,9 @@
 #include "pico/sync.h"
 #include "pico/time.h"
 #include "hardware/adc.h"
+#if PICO_RP2040
 #include "hardware/divider.h"
+#endif
 
 #include "sim.h"
 #include "simdefs.h"
@@ -311,7 +313,9 @@ static void __not_in_flash_func(lcd_draw_cpu_reg)(int first_flag)
 	BYTE r;
 	char *p;
 	int temp;
+#if PICO_RP2040
 	divmod_result_t res;
+#endif
 	static int cpu_type, counter;
 
 	if (first_flag || (cpu_type != cpu)) {
@@ -538,6 +542,7 @@ static void __not_in_flash_func(lcd_draw_cpu_reg)(int first_flag)
 			/*                  xx xx   */
 			counter = 0;
 			temp = (int) (read_onboard_temp() * 100.0f + 0.5f);
+#if PICO_RP2040
 			res = hw_divider_divmod_u32(temp, 10);
 			cpu_char20(21, 5, '0' + to_remainder_u32(res), BRRED);
 			res = hw_divider_divmod_u32(to_quotient_u32(res), 10);
@@ -546,6 +551,15 @@ static void __not_in_flash_func(lcd_draw_cpu_reg)(int first_flag)
 			cpu_char20(18, 5, '0' + to_remainder_u32(res), BRRED);
 			res = hw_divider_divmod_u32(to_quotient_u32(res), 10);
 			cpu_char20(17, 5, '0' + to_remainder_u32(res), BRRED);
+#else
+			cpu_char20(21, 5, '0' + temp % 10, BRRED);
+			temp /= 10;
+			cpu_char20(20, 5, '0' + temp % 10, BRRED);
+			temp /= 10;
+			cpu_char20(18, 5, '0' + temp % 10, BRRED);
+			temp /= 10;
+			cpu_char20(17, 5, '0' + temp % 10, BRRED);
+#endif
 		}
 	}
 }

--- a/srcsim/simcfg.c
+++ b/srcsim/simcfg.c
@@ -100,6 +100,9 @@ void config(void)
 	static const char *dotw[7] = { "Sun", "Mon", "Tue", "Wed",
 				       "Thu", "Fri", "Sat" };
 	struct timespec ts;
+	struct ds3231_rtc rtc;
+	ds3231_datetime_t dt;
+	uint8_t buf;
 	UNUSED(DS3231_MONTHS);
 	UNUSED(DS3231_WDAYS);
 
@@ -131,30 +134,16 @@ void config(void)
 	}
 
 	/* Create a real-time clock structure and initiate this */
-	struct ds3231_rtc rtc;
 	ds3231_init(i2c_default, PICO_DEFAULT_I2C_SDA_PIN,
 		    PICO_DEFAULT_I2C_SCL_PIN, &rtc);
 
-	/* A `ds3231_datetime_t` structure holds date and time values. It is */
-	/* used first to set the initial (user-defined) date/time. After */
-	/* these initial values are set, then this same structure will be */
-	/* updated by the ds3231 functions as needed with the most current */
-	/* time and date values. */
-	ds3231_datetime_t dt = {
-		.year = 2000,	/* Year (2000-2099) */
-		.month = 1,	/* Month (1-12, 1=January, 12=December) */
-		.day = 1,	/* Day (1-31) */
-		.hour = 0,	/* Hour, in 24-h format (0-23) */
-		.minutes = 0,	/* Minutes (0-59) */
-		.seconds = 0,	/* Seconds (0-59) */
-		.dotw = 1,	/* Day of the week (1-7, 1=Monday, 7=Sunday) */
-	};
-
-	/* Read the date and time from the DS3231 RTC */
-	ds3231_get_datetime(&dt, &rtc);
-
-	/* if we read something take it over */
-	if (dt.year != 2000) {
+	/* Try to read the DS3231 RTC status register */
+	buf = DS3231_STATUS_REG;
+	i2c_write_blocking(rtc.i2c_port, rtc.i2c_addr, &buf, 1, true);
+	if (i2c_read_blocking(rtc.i2c_port, rtc.i2c_addr,
+			      &buf, 1, false) == 1) {
+		/* Read the date and time from the DS3231 RTC */
+		ds3231_get_datetime(&dt, &rtc);
 		t.tm_year = dt.year - 1900;
 		t.tm_mon = dt.month - 1;
 		t.tm_mday = dt.day;


### PR DESCRIPTION
The DS3231 library doesn't check if the chip is really there and returns random values when it is not.

Replace previous code with a check if we can successfully read the status register of the DS3231 (i.e. get a byte back).

I got the "Thu 2004-10-28 00:00:23" date whenever my GEEK-RP2350 restarted.

Please test that it still works when the chip is connected.