### PR TITLE
use DMA transfer with interrupt for the LCD refresh

### DIFF
--- a/libs/lcd/Config/CMakeLists.txt
+++ b/libs/lcd/Config/CMakeLists.txt
@@ -6,8 +6,9 @@ target_include_directories(lcd-Config INTERFACE
 
 target_link_libraries(lcd-Config INTERFACE
 	pico_stdlib
-	hardware_spi
 	hardware_pwm
+	hardware_spi
+	hardware_sync
 )
 
 target_sources(lcd-Config INTERFACE

--- a/libs/lcd/GUI/GUI_NewImage.c
+++ b/libs/lcd/GUI/GUI_NewImage.c
@@ -14,7 +14,6 @@ parameter:
 void Paint_NewImage(uint8_t *image, uint16_t Width, uint16_t Height,
 		    uint16_t Rotate, uint16_t Color)
 {
-	Paint.Image = NULL;
 	Paint.Image = image;
 
 	Paint.WidthMemory = Width;

--- a/libs/lcd/LCD/include/LCD_1in14_V2.h
+++ b/libs/lcd/LCD/include/LCD_1in14_V2.h
@@ -50,7 +50,7 @@ extern void LCD_1IN14_V2_Init(uint8_t Scan_dir);
 extern void LCD_1IN14_V2_Exit(void);
 extern void LCD_1IN14_V2_SetRotated(uint8_t Rotated);
 extern void LCD_1IN14_V2_Clear(uint16_t Color);
-extern void LCD_1IN14_V2_Display(uint16_t *Image);
+extern void LCD_1IN14_V2_Display16(uint8_t *Image);
 extern void LCD_1IN14_V2_Display12(uint8_t *Image);
 extern void LCD_1IN14_V2_DisplayWindows(uint16_t Xstart, uint16_t Ystart,
 					uint16_t Xend, uint16_t Yend,

--- a/srcsim/CMakeLists.txt
+++ b/srcsim/CMakeLists.txt
@@ -78,8 +78,8 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 	PICO_HEAP_SIZE=8192
 	# LCD frame buffer color depth (12 or 16 bits)
 	LCD_COLOR_DEPTH=12
-	# LCD refresh rate in Hz (30 works well with 12-bit frame buffer)
-	LCD_REFRESH=30
+	# LCD refresh rate in Hz (60 works well with 12-bit frame buffer)
+	LCD_REFRESH=60
 	USBD_MANUFACTURER="Z80pack"
 )
 if(PICO_RP2040)

--- a/srcsim/disks.c
+++ b/srcsim/disks.c
@@ -45,6 +45,7 @@ static unsigned char __aligned(4) dsk_buf[SEC_SZ];
 static sd_sdio_if_t sdio_if = {
 	.CMD_gpio = PICO_SD_CMD_PIN,
 	.D0_gpio = PICO_SD_DAT0_PIN,
+	.DMA_IRQ_num = DMA_IRQ_0,
 #if PICO_RP2040
 	//.baud_rate = 125 * 1000 * 1000 / 8,	/* 15.625 MHz */
 	.baud_rate = 125 * 1000 * 1000 / 6,	/* 20.833333 MHz */


### PR DESCRIPTION
Now runs with 60Hz even on the RP2040. The RP2350 can also use 60Hz with LCD_COLOR_DEPTH set to 16.

Add DMA_IRQ_num initializer to sdio_if even if it is the default, so we know it uses DMA_IRQ_0. The LCD code uses DMA_IRQ_1.

Moved the LCD initialization/deinitialization code into lcd_task(), since the interrupt setup must be run on the core that will receive the interrupts.