### PR TITLE
LCD library clean-ups

### DIFF
--- a/libs/lcd/Config/include/DEV_Config.h
+++ b/libs/lcd/Config/include/DEV_Config.h
@@ -43,7 +43,7 @@
 #define DEV_DMA_IRQ	(DMA_IRQ_1)
 
 extern uint DEV_DMA_Channel;
-extern bool DEV_DMA_Done;
+extern bool DEV_DMA_Active;
 extern void (*DEV_DMA_Done_Func)(void);
 extern uint DEV_PWM_Slice_Num;
 
@@ -75,10 +75,10 @@ static inline void DEV_SPI_Write_nByte(uint8_t *pData, uint32_t Len)
 	spi_write_blocking(DEV_SPI_PORT, pData, Len);
 }
 
-static inline void DEV_SPI_Write_DMA(uint8_t *pData, uint32_t Len,
-				     void (*Done_Func)(void))
+static inline void DEV_SPI_Start_DMA_Write(uint8_t *pData, uint32_t Len,
+					   void (*Done_Func)(void))
 {
-	DEV_DMA_Done = false;
+	DEV_DMA_Active = true;
 	DEV_DMA_Done_Func = Done_Func;
 	dma_channel_transfer_from_buffer_now(DEV_DMA_Channel, pData, Len);
 }
@@ -88,7 +88,7 @@ static inline void DEV_SPI_Write_DMA(uint8_t *pData, uint32_t Len,
  */
 static inline void DEV_Wait_DMA_Done(void)
 {
-	while (!DEV_DMA_Done)
+	while (DEV_DMA_Active)
 		__wfi();
 }
 

--- a/libs/lcd/LCD/LCD_1in14_V2.c
+++ b/libs/lcd/LCD/LCD_1in14_V2.c
@@ -288,6 +288,8 @@ void LCD_1IN14_V2_Clear(uint16_t Color)
 	uint16_t j, i;
 
 	DEV_Wait_DMA_Done();
+	LCD_1IN14_V2_SendCommand(0x3a); /* Interface Pixel Format */
+	LCD_1IN14_V2_SendData_8Bit(0x05); /* 16-bit */
 	LCD_1IN14_V2_SetWindows(0, 0, LCD_1IN14_V2.WIDTH, LCD_1IN14_V2.HEIGHT);
 	DEV_Digital_Write(WAVESHARE_GEEK_LCD_DC_PIN, 1);
 	DEV_Digital_Write(WAVESHARE_GEEK_LCD_CS_PIN, 0);
@@ -306,13 +308,7 @@ parameter:
 ******************************************************************************/
 static void __not_in_flash_func(LCD_1IN14_V2_DMA_Done)(void)
 {
-	/* DMA transfer done doesn't mean that the SPI FIFO is also empty */
-	while (spi_is_busy(DEV_SPI_PORT))
-		tight_loop_contents();
 	DEV_Digital_Write(WAVESHARE_GEEK_LCD_CS_PIN, 1);
-	LCD_1IN14_V2_SendCommand(0x29); /* Display On */
-	LCD_1IN14_V2_SendCommand(0x3a); /* Interface Pixel Format */
-	LCD_1IN14_V2_SendData_8Bit(0x05); /* 16-bit */
 }
 
 /******************************************************************************
@@ -324,10 +320,12 @@ void __not_in_flash_func(LCD_1IN14_V2_Display16)(uint8_t *Image)
 	const uint32_t n = LCD_1IN14_V2.HEIGHT * LCD_1IN14_V2.WIDTH * 2;
 
 	DEV_Wait_DMA_Done();
+	LCD_1IN14_V2_SendCommand(0x3a); /* Interface Pixel Format */
+	LCD_1IN14_V2_SendData_8Bit(0x05); /* 16-bit */
 	LCD_1IN14_V2_SetWindows(0, 0, LCD_1IN14_V2.WIDTH, LCD_1IN14_V2.HEIGHT);
 	DEV_Digital_Write(WAVESHARE_GEEK_LCD_DC_PIN, 1);
 	DEV_Digital_Write(WAVESHARE_GEEK_LCD_CS_PIN, 0);
-	DEV_SPI_Write_DMA(Image, n, LCD_1IN14_V2_DMA_Done);
+	DEV_SPI_Start_DMA_Write(Image, n, LCD_1IN14_V2_DMA_Done);
 }
 
 /******************************************************************************
@@ -345,7 +343,7 @@ void __not_in_flash_func(LCD_1IN14_V2_Display12)(uint8_t *Image)
 	LCD_1IN14_V2_SetWindows(0, 0, LCD_1IN14_V2.WIDTH, LCD_1IN14_V2.HEIGHT);
 	DEV_Digital_Write(WAVESHARE_GEEK_LCD_DC_PIN, 1);
 	DEV_Digital_Write(WAVESHARE_GEEK_LCD_CS_PIN, 0);
-	DEV_SPI_Write_DMA(Image, n, LCD_1IN14_V2_DMA_Done);
+	DEV_SPI_Start_DMA_Write(Image, n, LCD_1IN14_V2_DMA_Done);
 }
 
 /******************************************************************************
@@ -364,6 +362,8 @@ void LCD_1IN14_V2_DisplayWindows(uint16_t Xstart, uint16_t Ystart,
 	uint16_t j;
 
 	DEV_Wait_DMA_Done();
+	LCD_1IN14_V2_SendCommand(0x3a); /* Interface Pixel Format */
+	LCD_1IN14_V2_SendData_8Bit(0x05); /* 16-bit */
 	LCD_1IN14_V2_SetWindows(Xstart, Ystart, Xend, Yend);
 	DEV_Digital_Write(WAVESHARE_GEEK_LCD_DC_PIN, 1);
 	DEV_Digital_Write(WAVESHARE_GEEK_LCD_CS_PIN, 0);
@@ -386,6 +386,8 @@ parameter:
 void LCD_1IN14_V2_DisplayPoint(uint16_t X, uint16_t Y, uint16_t Color)
 {
 	DEV_Wait_DMA_Done();
+	LCD_1IN14_V2_SendCommand(0x3a); /* Interface Pixel Format */
+	LCD_1IN14_V2_SendData_8Bit(0x05); /* 16-bit */
 	LCD_1IN14_V2_SetWindows(X, Y, X, Y);
 	LCD_1IN14_V2_SendData_16Bit(Color);
 }


### PR DESCRIPTION
Rename DEV_DMA_Done to DEV_DMA_Active.
Rename DEV_SPI_Write_DMA to DEV_SPI_Start_DMA_Write.

Moved SPI busy loop into DEV_DMA_IRQ_Handler(), looks more at home there.

Set pixel format in every function that sents pixels, so the sequence is always: set Pixel Format - call SetWindows() - send pixels.

Remove "Display On", this is done by LCD_1IN14_V2_InitReg(), and nothing does a "Display Off".

Small story:
While writing the DMA code, by taking hints from pico-examples, and after I thought "looks good, let's test this", the display showed the "Waiting for terminal" and then went blank... Sprinkling some "puts()" into the code, to see whats going on, and it works! WTF? I think everybody hates it when that happens. After some mumbling and thinking, I came up with the "SPI FIFO not empty, when DMA write finished interrupt triggers".