### PR TITLE
tweaks to drives panel

### DIFF
--- a/srcsim/disks.c
+++ b/srcsim/disks.c
@@ -86,8 +86,6 @@ void init_disks(void)
 	sd_res = f_mount(&fs, "", 1);
 	if (sd_res != FR_OK)
 		panic("f_mount error: %s (%d)\n", FRESULT_str(sd_res), sd_res);
-
-	lcd_init_drives();
 }
 
 void exit_disks(void)

--- a/srcsim/disks.c
+++ b/srcsim/disks.c
@@ -311,7 +311,7 @@ BYTE write_sec(int drive, int track, int sector, WORD addr)
 
 	/* prepare for sector write */
 	stat = prep_io(drive, track, sector, addr, true);
-	if (stat== FDC_STAT_OK) {
+	if (stat == FDC_STAT_OK) {
 
 		/* write sector to disk image */
 		for (i = 0; i < SEC_SZ; i++)

--- a/srcsim/draw.h
+++ b/srcsim/draw.h
@@ -37,6 +37,7 @@
 #define C_DKYELLOW	0x0880
 #define C_GRAY		0x0888
 #define C_ORANGE	0x0fa0
+#define C_WHEAT		0x0edb
 #else
 /* 565 RGB colors */
 #define C_BLACK		0x0000
@@ -55,6 +56,7 @@
 #define C_DKYELLOW	0x4c40
 #define C_GRAY		0x8410
 #define C_ORANGE	0xfd20
+#define C_WHEAT		0xf6f6
 #endif
 
 /*

--- a/srcsim/fonts/bdf2c.c
+++ b/srcsim/fonts/bdf2c.c
@@ -164,8 +164,8 @@ int main(int argc, char *argv[])
 					if ((mc >>= 1) == 0) {
 						/* get next hex char */
 						c = *s++;
-						c = c - (c <= '9' ? '0'
-								  : 'A' - 10);
+						c -= (c <= '9' ? '0'
+							       : 'A' - 10);
 						mc = 0x8;
 					}
 					if (c & mc)

--- a/srcsim/lcd.h
+++ b/srcsim/lcd.h
@@ -29,7 +29,6 @@ extern void lcd_custom_disp(lcd_func_t draw_func);
 extern void lcd_status_disp(int which);
 extern void lcd_status_next(void);
 extern void lcd_brightness(int brightness);
-extern void lcd_init_drives(void);
 extern void lcd_update_drive(int drive, int track, int sector, WORD addr,
 			     bool rdwr, bool active);
 


### PR DESCRIPTION
Change 'D' to 'A' for address.

Use another color for S/T/A to not clash with the green LED.

Clear values after 10 seconds of no access to a drive.