### PR TITLE
clean-up lcd code

### DIFF
--- a/srcsim/lcd.c
+++ b/srcsim/lcd.c
@@ -106,11 +106,11 @@ static void __not_in_flash_func(lcd_task)(void)
 	lcd_func_t draw_func, new_draw_func;
 
 	/* initialize the LCD controller */
-	lcd_dev_init(lcd_backlight);
 	backlight = lcd_backlight;
 	rotated = false;
 	draw_func = NULL;
 	first = true;
+	lcd_dev_init(backlight);
 
 	while (1) {
 		/* loops every LCD_REFRESH_US */

--- a/srcsim/lcd.c
+++ b/srcsim/lcd.c
@@ -107,10 +107,11 @@ static void __not_in_flash_func(lcd_task)(void)
 
 	/* initialize the LCD controller */
 	backlight = lcd_backlight;
+	lcd_dev_init(backlight);
+
 	rotated = false;
 	draw_func = NULL;
 	first = true;
-	lcd_dev_init(backlight);
 
 	while (1) {
 		/* loops every LCD_REFRESH_US */

--- a/srcsim/lcd.h
+++ b/srcsim/lcd.h
@@ -21,14 +21,15 @@
 
 typedef void (*lcd_func_t)(bool first);
 
-extern uint16_t led_color;
+extern uint16_t led_color;	/* call lcd_update_led() after changing this */
 
 extern void lcd_init(void), lcd_exit(void);
+extern void lcd_brightness(int brightness);
 extern void lcd_set_rotation(bool rotated);
+extern void lcd_update_led(void);
 extern void lcd_custom_disp(lcd_func_t draw_func);
 extern void lcd_status_disp(int which);
 extern void lcd_status_next(void);
-extern void lcd_brightness(int brightness);
 extern void lcd_update_drive(int drive, int track, int sector, WORD addr,
 			     bool rdwr, bool active);
 

--- a/srcsim/lcd_dev.c
+++ b/srcsim/lcd_dev.c
@@ -97,7 +97,7 @@ static const uint8_t lcd_init_tab[] = {
 /*
  *	Initialize LCD controller
  */
-void lcd_dev_init(void)
+void lcd_dev_init(uint8_t backlight)
 {
 	dma_channel_config c;
 	const uint8_t *p;
@@ -161,7 +161,7 @@ void lcd_dev_init(void)
 	sleep_ms(100);
 
 	/* set LCD backlight intensity */
-	lcd_dev_backlight(90);
+	lcd_dev_backlight(backlight);
 
 	/* initialize LCD controller registers */
 	for (p = lcd_init_tab; *p != 0xff;) {

--- a/srcsim/lcd_dev.h
+++ b/srcsim/lcd_dev.h
@@ -12,7 +12,7 @@
 
 #include "draw.h"
 
-extern void lcd_dev_init(void);
+extern void lcd_dev_init(uint8_t backlight);
 extern void lcd_dev_exit(void);
 extern void lcd_dev_backlight(uint8_t value);
 extern void lcd_dev_rotation(bool rotated);

--- a/srcsim/simio.c
+++ b/srcsim/simio.c
@@ -191,6 +191,7 @@ static void p000_out(BYTE data)
 		/* everything else on */
 		led_color = (led_color & ~C_BLUE) | C_BLUE;
 	}
+	lcd_update_led();
 }
 
 /*


### PR DESCRIPTION
Move all LCD controller accesses into lcd_task(), drop mutex.

Keep a global LCD frame counter and use this for the disk drive last access time, so the displayed status is correct after switching panels or using Dazzler.

Use "volatile" for the variables used to communicate between the cores.

After changing "led_color" one must now call "lcd_led_update()".

Combine 'lcd_info_first()" and "lcd_info_update()" into "lcd_draw_info()", and use the global frame counter.

Add initial backlight value as a parameter to "lcd_dev_init()".

Hopefully my thinking is right regarding multiple core variable accesses and possible races.