### PR TITLE
add delay for RP2040 for aon_timer calls that set the time

### DIFF
--- a/srcsim/simcfg.c
+++ b/srcsim/simcfg.c
@@ -163,6 +163,9 @@ void config(void)
 	ts.tv_sec = mktime(&t);
 	ts.tv_nsec = 0;
 	aon_timer_start(&ts);
+#if PICO_RP2040
+	sleep_us(64);
+#endif
 
 	lcd_brightness(brightness);
 	lcd_set_rotation(rotated);
@@ -293,6 +296,9 @@ void config(void)
 				ds3231_set_datetime(&dt, &rtc);
 				ts.tv_sec = mktime(&t);
 				aon_timer_set_time(&ts);
+#if PICO_RP2040
+				sleep_us(64);
+#endif
 			}
 			putchar('\n');
 			break;
@@ -321,6 +327,9 @@ void config(void)
 				ds3231_set_datetime(&dt, &rtc);
 				ts.tv_sec = mktime(&t);
 				aon_timer_set_time(&ts);
+#if PICO_RP2040
+				sleep_us(64);
+#endif
 			}
 			putchar('\n');
 			break;


### PR DESCRIPTION
Previously we used the RTC directly on the RP2040 and as the SDK manual says used delay after setting the RTC.

The aon_timer (which use the RTC on the RP2040) time setting functions don't delay.

Does this change anything?